### PR TITLE
Switch to bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# mineTomek's Website
+
+This is a [Next.js](https://nextjs.org/) based website for mineTomek (*made by mineTomek*).
+
+## Where is this website?
+
+This website is hosted on vercel and for now has this domain: https://mine-tomek-website.vercel.app/. The individual branches can be accessed with this url: `https://mine-tomek-website-git-[branch_name]-minetomek.vercel.app`, for example `https://mine-tomek-website-git-improve-layout-and-styling-minetomek.vercel.app`.
 
 ## Getting Started
 
@@ -16,25 +22,8 @@ bun run dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `src/app/page.tsx`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+## Contributing
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
-
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+If you have any ideas or want to contribute in any way, feel free to [fork this repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo), and then [create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests). I will be happy to consider every single one.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ npm run dev
 yarn dev
 # or
 pnpm dev
+# or (preferred & fastest)
+bun run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.


### PR DESCRIPTION
I thought that switching to bun would be harder, but apparently, you can just use `bun run dev` instead of `npm run dev`. So I updated to readme to include bun as an option and label it as the best. As I already touched README, I changed almost every aspect of it to be tailored for this project.