### PR TITLE
Add side menu functionality

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { getTitleFont } from '../fonts'
 import Logo from './Logo'
 import { faBars } from '@fortawesome/free-solid-svg-icons'
 import Link from 'next/link'
+import SideMenu from './navbar/SideMenu'
 
 export default function Navbar() {
   return (
@@ -18,6 +19,7 @@ export default function Navbar() {
         icon={faBars}
         className='h-8 w-8'
       />
+      <SideMenu />
     </div>
   )
 }

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -17,7 +17,7 @@ export default function Navbar() {
       </Link>
       <FontAwesomeIcon
         icon={faBars}
-        className='h-8 w-8'
+        className='pointer-events-none z-20 h-8 w-8'
       />
       <SideMenu />
     </div>

--- a/src/app/components/navbar/SideMenu.tsx
+++ b/src/app/components/navbar/SideMenu.tsx
@@ -62,7 +62,7 @@ export default function SideMenu() {
         }`}
         onClick={_e => setIsOpen(prev => !prev)}
       >
-        <motion.p variants={{ open: { opacity: 1 }, closed: { opacity: 0 } }}>
+        <motion.p variants={{ open: { opacity: 1 }, closed: { opacity: 0.3 } }}>
           Menu
         </motion.p>
       </div>

--- a/src/app/components/navbar/SideMenu.tsx
+++ b/src/app/components/navbar/SideMenu.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import SideMenuItem from '@/app/types/SideMenuItem'
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Variants, motion } from 'framer-motion'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -78,7 +80,15 @@ export default function SideMenu() {
             key={`menu_item_${i}`}
             variants={menuItem}
           >
-            <Link href={item.href} onClick={_e => setIsOpen(false)}>{item.label}</Link>
+            <Link
+              href={item.href}
+              onClick={_e => setIsOpen(false)}
+            >
+              {item.label}
+              {currentPath !== item.href && (
+                <FontAwesomeIcon icon={faArrowUpRightFromSquare} />
+              )}
+            </Link>
           </motion.div>
         ))}
       </motion.div>

--- a/src/app/components/navbar/SideMenu.tsx
+++ b/src/app/components/navbar/SideMenu.tsx
@@ -39,14 +39,17 @@ const menuItems: SideMenuItem[] = [
   {
     label: 'Main Page',
     href: '/',
+    subItems: [],
   },
   {
     label: 'Blog',
     href: '/blog',
+    subItems: [],
   },
   {
     label: 'Project Timeline',
     href: '/timeline',
+    subItems: [],
   },
 ]
 

--- a/src/app/components/navbar/SideMenu.tsx
+++ b/src/app/components/navbar/SideMenu.tsx
@@ -3,6 +3,7 @@
 import SideMenuItem from '@/app/types/SideMenuItem'
 import { Variants, motion } from 'framer-motion'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { useState } from 'react'
 
 const sidebar: Variants = {
@@ -49,6 +50,8 @@ const menuItems: SideMenuItem[] = [
 
 export default function SideMenu() {
   const [isOpen, setIsOpen] = useState(false)
+
+  const currentPath = usePathname()
 
   return (
     <motion.div

--- a/src/app/components/navbar/SideMenu.tsx
+++ b/src/app/components/navbar/SideMenu.tsx
@@ -57,8 +57,8 @@ export default function SideMenu() {
       animate={isOpen ? 'open' : 'closed'}
     >
       <div
-        className={`ml-auto flex h-16 flex-col justify-center bg-zinc-100 pl-5 transition-[background-color,width] ${
-          isOpen ? 'w-full dark:bg-zinc-900' : 'w-16 dark:bg-zinc-800'
+        className={`ml-auto flex h-16 cursor-pointer flex-col justify-center bg-zinc-100 transition-[background-color,width] ${
+          isOpen ? 'w-ful pl-4 dark:bg-zinc-900' : 'w-16 pl-16 dark:bg-zinc-800'
         }`}
         onClick={_e => setIsOpen(prev => !prev)}
       >

--- a/src/app/components/navbar/SideMenu.tsx
+++ b/src/app/components/navbar/SideMenu.tsx
@@ -83,6 +83,9 @@ export default function SideMenu() {
             <Link
               href={item.href}
               onClick={_e => setIsOpen(false)}
+              className={`flex justify-between ${
+                currentPath === item.href && 'bold text-primary-300'
+              }`}
             >
               {item.label}
               {currentPath !== item.href && (

--- a/src/app/components/navbar/SideMenu.tsx
+++ b/src/app/components/navbar/SideMenu.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import SideMenuItem from '@/app/types/SideMenuItem'
+import { Variants, motion } from 'framer-motion'
+import Link from 'next/link'
+import { useState } from 'react'
+
+const sidebar: Variants = {
+  open: {
+    transform: 'translateX(0)',
+
+    transition: {
+      delayChildren: 0.2,
+      staggerChildren: 0.1,
+    },
+  },
+  closed: {
+    transform: 'translateX(100%)',
+
+    transition: {},
+  },
+}
+
+const menuItem: Variants = {
+  open: {
+    transform: 'translateY(0) scale(1)',
+    opacity: 1,
+  },
+  closed: {
+    transform: 'translateY(1rem) scale(.7)',
+    opacity: 0,
+  },
+}
+
+const menuItems: SideMenuItem[] = [
+  {
+    label: 'Main Page',
+    href: '/',
+  },
+  {
+    label: 'Blog',
+    href: '/blog',
+  },
+  {
+    label: 'Project Timeline',
+    href: '/timeline',
+  },
+]
+
+export default function SideMenu() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <motion.div
+      className='fixed bottom-0 right-0 top-0 z-10 w-80 gap-2'
+      initial={false}
+      animate={isOpen ? 'open' : 'closed'}
+    >
+      <div
+        className={`ml-auto flex h-16 flex-col justify-center bg-zinc-100 pl-5 transition-[background-color,width] ${
+          isOpen ? 'w-full dark:bg-zinc-900' : 'w-16 dark:bg-zinc-800'
+        }`}
+        onClick={_e => setIsOpen(prev => !prev)}
+      >
+        <motion.p variants={{ open: { opacity: 1 }, closed: { opacity: 0 } }}>
+          Menu
+        </motion.p>
+      </div>
+      <motion.div
+        className='z-20 flex flex-col gap-2 rounded-bl-lg bg-zinc-100 p-4 dark:bg-zinc-700'
+        variants={sidebar}
+      >
+        {menuItems.map((item, i) => (
+          <motion.div
+            key={`menu_item_${i}`}
+            variants={menuItem}
+          >
+            <Link href={item.href} onClick={_e => setIsOpen(false)}>{item.label}</Link>
+          </motion.div>
+        ))}
+      </motion.div>
+    </motion.div>
+  )
+}

--- a/src/app/types/SideMenuItem.ts
+++ b/src/app/types/SideMenuItem.ts
@@ -1,0 +1,5 @@
+export default interface SideMenuItem {
+  label: string
+  href: string
+  //   subItems: SideMenuItem[]
+}

--- a/src/app/types/SideMenuItem.ts
+++ b/src/app/types/SideMenuItem.ts
@@ -1,5 +1,5 @@
 export default interface SideMenuItem {
   label: string
   href: string
-  //   subItems: SideMenuItem[]
+  subItems: SideMenuItem[]
 }


### PR DESCRIPTION
This PR adds the side menu opened by clicking on the bars icon and closed by clicking anywhere on the dark gray bar that's the part of that menu.
The menu itself contains list of links to various pages with the one that's the current page being highlighted.
In case of animations it's full of them. Including open, close and staggered url list.